### PR TITLE
Use latest PyMC3 and ArviZ to automatically take coords from model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymc3
+pymc3 >=3.9.2
 pandas
 jupyterlab
 numpy


### PR DESCRIPTION
PyMC3 3.9.2 depends on ArviZ 0.9.0 which can automatically grab coords & dims from PyMC3 models.

With these changes, all variables in `InferenceData` get coords.

`observed_data.nonzero_positive` is the only one where the coord name actually changed (from `nonzero_positive_dim_0`), but as fas as I can tell, it wasn't used anywhere, so I kept the model version number.

Posterior:
```
 <xarray.Dataset>
Dimensions:                 (chain: 4, date: 122, draw: 200)
Coordinates:
  * chain                   (chain) int64 0 1 2 3
  * draw                    (draw) int64 0 1 2 3 4 5 ... 194 195 196 197 198 199
  * date                    (date) datetime64[ns] 2020-02-24 ... 2020-06-24
Data variables:
    log_r_t                 (chain, draw, date) float64 ...
    r_t                     (chain, draw, date) float64 ...
    seed                    (chain, draw) float64 ...
    infections              (chain, draw, date) float64 ...
    test_adjusted_positive  (chain, draw, date) float64 ...
    exposure                (chain, draw, date) float64 ...
    positive                (chain, draw, date) float64 ...
    alpha                   (chain, draw) float64 ...
Attributes:
    created_at:                 2020-06-25T17:51:08.109475
    arviz_version:              0.9.0
    inference_library:          pymc3
    inference_library_version:  3.9.2
    sampling_time:              374.5396087169647
    tuning_steps:               700
    model_version:              1.0.0 
```

Observed:
```
 <xarray.Dataset>
Dimensions:           (nonzero_date: 111)
Coordinates:
  * nonzero_date      (nonzero_date) datetime64[ns] 2020-03-05 ... 2020-06-24
Data variables:
    nonzero_positive  (nonzero_date) float64 ...
Attributes:
    created_at:                 2020-06-25T17:51:09.183600
    arviz_version:              0.9.0
    inference_library:          pymc3
    inference_library_version:  3.9.2 
```

Constant:
```
 <xarray.Dataset>
Dimensions:                    (date: 122, nonzero_date: 111)
Coordinates:
  * date                       (date) datetime64[ns] 2020-02-24 ... 2020-06-24
  * nonzero_date               (nonzero_date) datetime64[ns] 2020-03-05 ... 2020-06-24
Data variables:
    exposure                   (date) float64 ...
    tests                      (date) float64 ...
    observed_positive          (date) float64 ...
    nonzero_observed_positive  (nonzero_date) float64 ...
Attributes:
    created_at:                 2020-06-25T17:51:09.185548
    arviz_version:              0.9.0
    inference_library:          pymc3
    inference_library_version:  3.9.2 
```