### PR TITLE
bring back support for old run_dates

### DIFF
--- a/covid/data.py
+++ b/covid/data.py
@@ -19,7 +19,7 @@ def process_covidtracking_data(data: pd.DataFrame, run_date: pd.Timestamp):
     data = data.rename(columns={"state": "region"})
     data["date"] = pd.to_datetime(data["date"], format="%Y%m%d")
     data = data.set_index(["region", "date"]).sort_index()
-    data = data.loc[idx[:, :run_date], ["positive", "total"]]
+    data = data[["positive", "total"]]
 
     # Too little data or unreliable reporting in the data source.
     data = data.drop(["MP", "GU", "AS", "PR", "VI"])
@@ -34,7 +34,7 @@ def process_covidtracking_data(data: pd.DataFrame, run_date: pd.Timestamp):
     data.loc[idx["LA", pd.Timestamp("2020-06-19") :], :] += 1666
 
     # Now work with daily counts
-    data = data.diff().dropna().clip(0, None)
+    data = data.diff().dropna().clip(0, None).sort_index()
 
     # Michigan missed 6/18 totals and lumped them into 6/19 so we've
     # divided the totals in two and equally distributed to both days.
@@ -80,7 +80,8 @@ def process_covidtracking_data(data: pd.DataFrame, run_date: pd.Timestamp):
         :,
     ] = 0
 
-    return data
+    # the right bound of the slice has a -1 day, because the diff operation adds a day to the end
+    return data.loc[idx[:, :(run_date - pd.DateOffset(1))], ["positive", "total"]]
 
 
 def get_and_process_covidtracking_data(run_date: pd.Timestamp):

--- a/covid/data.py
+++ b/covid/data.py
@@ -80,7 +80,8 @@ def process_covidtracking_data(data: pd.DataFrame, run_date: pd.Timestamp):
         :,
     ] = 0
 
-    # the right bound of the slice has a -1 day, because the diff operation adds a day to the end
+    # At the real time of `run_date`, the data for `run_date` is not yet available!
+    # Cutting it away is important for backtesting!
     return data.loc[idx[:, :(run_date - pd.DateOffset(1))], ["positive", "total"]]
 
 

--- a/covid/tests.py
+++ b/covid/tests.py
@@ -16,8 +16,12 @@ class TestDataUS:
 
     def test_process(self):
         df_raw = covid.data.get_raw_covidtracking_data()
-        df_processed = covid.data.process_covidtracking_data(df_raw, pandas.Timestamp('2020-06-25'))
+        run_date = pandas.Timestamp('2020-06-25')
+        df_processed = covid.data.process_covidtracking_data(df_raw, run_date)
         assert isinstance(df_processed, pandas.DataFrame)
+        # the last entry in the data is the day before `run_date`!
+        assert df_processed.xs('NY').index[-1] < run_date
+        assert df_processed.xs('NY').index[-1] == (run_date - pandas.DateOffset(1))
 
 
 class TestGenerative:


### PR DESCRIPTION
This PR fixes compatibility of the data processing function with old run_dates that are before the outlier correction dates.
(The reason why the CI fails on master.)

My day is super packed, so if someone could double check the part about the `DateOffset` in line 84 that would be great!
(manual before/after comparison)

closes #13