### PR TITLE
Remove unnecessary channel specifications in pipeline.yml

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,12 +16,12 @@ jobs:
         auto-update-conda: true
         activate-environment: covid-test
         python-version: ${{ matrix.python-version }}
-        channels: conda-forge,defaults
+        channels: conda-forge
         channel-priority: strict
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        conda install -c conda-forge --file requirements.txt
+        conda install --file requirements.txt
         conda install pytest pytest-cov
     - name: Test with pytest
       shell: bash -l {0}


### PR DESCRIPTION
The default channel is already included, and as we already add conda-forge we don't need to specify it again when installing dependencies. 

This should get rid of these warnings:
<img width="827" alt="image" src="https://user-images.githubusercontent.com/674200/86455668-3f317e00-bd21-11ea-8c35-7cc9beedccc0.png">
