### PR TITLE
Fix minor formatting errors in tutorial

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "An SIR model is in fact what `rt.live` used in the beginning. However, SIR/SEIR models are also just approximations of the real thing and come with quite a few assumptions baked in. The current model is simpler and makes fewer assumptions. In addition, the SIR model is described as an ODE which causes various technical problems. Solving the ODE is quite time-intensive and while closed-form approximations exist and are faster, we found that they are quite unreliable.\n",
     "\n",
-    "Instead, the current model uses a simple generative logic to explain how a initial pool of infected people spreads the disease at each time-point, according to the current reproduction factor.\n",
+    "Instead, the current model uses a simple generative logic to explain how an initial pool of infected people spreads the disease at each time-point, according to the current reproduction factor.\n",
     "\n",
     "## The generative model"
    ]

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "The implicit assumption in the generative process above is that an infected person is only infectious for a single day and that it then takes just one day to infect other people.\n",
     "\n",
-    "In reality, the time it takes for the primary person to infect others follows a distribution. They might infect one person the next day, two the day after etc. This delay distribution is officially known as the \"*generation time*\" and we will model it with a probability distribution from [this study](https://www.ijidonline.com/article/S1201-9712(20)30119-3/pdf) (the study actually provides an estimate for something closely related to the generation time but it's fine to use it for this)."
+    "In reality, the time it takes for the primary person to infect others follows a distribution. They might infect one person the next day, two the day after etc. This delay distribution is officially known as the \"*generation time*\" and we will model it with a probability distribution from [this study](https://www.ijidonline.com/article/S1201-9712%2820%2930119-3/pdf) (the study actually provides an estimate for something closely related to the generation time but it's fine to use it for this)."
    ]
   },
   {


### PR DESCRIPTION
Nothing all that important.

1. Changed "a initial pool" to "**an** initial pool".
2. URL-encoded the parentheses in the link to the <a href="https://www.ijidonline.com/article/S1201-9712(20)30119-3/pdf">serial interval paper</a> (changing `(` to `%28` and `)` to `%29`) because the closing parenthesis is currently breaking the link in the [GitHub preview](https://github.com/rtcovidlive/covid-model/blob/e6747bd74ce703694690068ab4d540d90637e5c4/tutorial.ipynb) of `tutorial.ipynb`.