### PR TITLE
Update data_us.py

### DIFF
--- a/covid/data_us.py
+++ b/covid/data_us.py
@@ -107,6 +107,12 @@ def process_covidtracking_data(data: pd.DataFrame, run_date: pd.Timestamp):
     data.loc[idx["TX", pd.Timestamp("2020-08-11")], :] = 0
 
     data.loc[idx["DE", pd.Timestamp("2020-08-14")], :] = 0
+    
+    # MA Aug. 19 report includes 565 "probable" cases for the entire week plus 262 positive tests for the day.
+    # Spread out the 565 evenly across the whole week
+    data.loc[idx["MA", pd.Timestamp("2020-08-19")],:] -= 565
+    data.loc[idx["MA", pd.Timestamp("2020-08-13"):pd.Timestamp("2020-08-19")],:] += 80
+    data.loc[idx["MA", pd.Timestamp("2020-08-15"):pd.Timestamp("2020-08-19")],:] += 1
 
     # Zero out any rows where positive tests equal or exceed total reported tests
     # Do not act on Wyoming as they report positive==total most days


### PR DESCRIPTION
From 
From https://covidtracking.com/data:

> On *August 12*, MA began reporting probable cases weekly, not daily. This can lead to apparent spikes in the data when the weekly numbers are incorporated, as happened on *August 19*. Beginning *August 20*, we will use MA's daily total case counts for its race and ethnicity data, which includes both confirmed and probable cases, and will backfill the previous week's case counts.

The net result of this was that all 565 probable cases from the week of August 13-19 were added to the 262 positive tests on Aug 19, resulting in an apparent spike. This change spreads those 565 cases evenly across the week. First, it subtracts the 565 cases from Aug 19. Then it adds 80 cases per day to Aug 13-Aug 19. Then it splits the remainder (5) across the last five days of the week.