### PR TITLE
Update data_us to fix MS

### DIFF
--- a/covid/data_us.py
+++ b/covid/data_us.py
@@ -117,7 +117,7 @@ def process_covidtracking_data(data: pd.DataFrame, run_date: pd.Timestamp):
     filtering_date = pd.Timestamp('2020-07-27')
     zero_filter = (data.positive >= data.total) & \
         (data.index.get_level_values('date') >= filtering_date) & \
-        (~data.index.get_level_values('region').isin(['WY']))
+        (~data.index.get_level_values('region').isin(['WY', 'MS']))
     data.loc[zero_filter, :] = 0
 
     # At the real time of `run_date`, the data for `run_date` is not yet available!


### PR DESCRIPTION
Mississippi has a similar issue to Wyoming where much of their data is excluded from your model because the positive often exceeds the total.

I took a look and the charts seem to omit data for Mississippi from many recent days.

It matches up perfectly with COVID Tracking project for the days it displays, but other days are completely omitted. 

By adding MS to the zero filter it should show the accurate data for Mississippi.

<img width="1176" alt="Screen Shot 2020-11-20 at 8 57 09 AM" src="https://user-images.githubusercontent.com/9788919/99828671-7cec4300-2b18-11eb-9141-cee6f8cd162f.png">
<img width="968" alt="Screen Shot 2020-11-20 at 8 56 01 AM" src="https://user-images.githubusercontent.com/9788919/99828674-81186080-2b18-11eb-8e00-a3d14a6124a9.png">
