### PR TITLE
Fix for empty hawaii plots

### DIFF
--- a/covid/data_us.py
+++ b/covid/data_us.py
@@ -113,11 +113,11 @@ def process_covidtracking_data(data: pd.DataFrame, run_date: pd.Timestamp):
     data.loc[idx["WA", pd.Timestamp("2020-09-22"):pd.Timestamp("2020-09-24")], :] = 0
 
     # Zero out any rows where positive tests equal or exceed total reported tests
-    # Do not act on Wyoming as they report positive==total most days
+    # Do not act on Wyoming and Hawaii as they report positive==total most days
     filtering_date = pd.Timestamp('2020-07-27')
     zero_filter = (data.positive >= data.total) & \
         (data.index.get_level_values('date') >= filtering_date) & \
-        (~data.index.get_level_values('region').isin(['WY']))
+        (~data.index.get_level_values('region').isin(['WY', 'HI']))
     data.loc[zero_filter, :] = 0
 
     # At the real time of `run_date`, the data for `run_date` is not yet available!


### PR DESCRIPTION
Case data for Hawaii suddenly stops after October 7 (https://rt.live/us/HI), which is causing a pathological extrapolation with a very large error bar in the summary plot across all states. These days are zero'd out due to reported positive==reported total. Added Hawaii to the list of exemptions to this filtering.