### PR TITLE
Upgrade pipeline.yml conda version

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,16 +9,18 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-    - uses: actions/checkout@v2
-    - name: Install miniconda
-      uses: goanpeca/setup-miniconda@v1
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Miniconda
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
+        miniconda-version: "latest"
+        auto-activate-base: true
         activate-environment: covid-test
         python-version: ${{ matrix.python-version }}
         channels: conda-forge
         channel-priority: strict
-    - name: Install dependencies
+    - name: Install Dependencies
       shell: bash -l {0}
       run: |
         conda install --file requirements.txt


### PR DESCRIPTION
### About PR:

**Bug:**
Master branch .github.workflows `pipeline.yml` uses Miniconda version: `goanpeca/setup-miniconda@v1` to install requirements and execute tests

**Fix:**
Upgrade version to `conda-incubator/setup-miniconda@v2` 

**Why:**
The bug was introduced when GitHub Actions [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) set-env and add-path commands.

**More Info:** 
[issue 1](https://github.com/conda-incubator/setup-miniconda/issues/99)
[issue 2](https://github.com/conda-incubator/setup-miniconda/issues/101)
